### PR TITLE
Fix an off-by-one error in getMessage

### DIFF
--- a/nm_c.c
+++ b/nm_c.c
@@ -26,7 +26,7 @@ uint8_t* getMessage(size_t *inputLength) {
   // `message[0]`).
   // `sizeof(*message)` will hence return the size in bytes of the type 
   // `message` points at, which means it's equivalent to `sizeof(uint_8)`.
-  uint8_t *message = calloc(messageLength, sizeof(*message));
+  uint8_t *message = calloc(messageLength+1, sizeof(*message));
   result = fread(message, sizeof(*message), messageLength, stdin);
   // `inputLength` is a pointer, so we store the length at the memory address it 
   // points at. This way we return 2 values at once from a function!


### PR DESCRIPTION
The first fread would read the length of the message excluding null terminator. Later the message is interpreted as null-terminated string by sendMessage. To ensure that the message ends with a null terminator rather than whatever garbage is left over after the allocated buffer add 1 to the message length when allocating the message buffer.